### PR TITLE
Fix header display and auto-close hamburger menu

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -69,6 +69,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
                 section.scrollIntoView({
                     behavior: 'smooth'
                 });
+                closeHamburgerMenu(); // Close the hamburger menu after link selection
             }
         });
     });
@@ -128,5 +129,9 @@ document.addEventListener('DOMContentLoaded', (event) => {
             spread: 70,
             origin: { y: 0.6 }
         });
+    }
+
+    function closeHamburgerMenu() {
+        sidebar.classList.remove('visible');
     }
 });

--- a/styles.css
+++ b/styles.css
@@ -205,3 +205,13 @@ body {
 #sidebar ul li a:hover {
     text-decoration: underline;
 }
+
+/* Adjust header margin to prevent overlap */
+.fixed-header {
+    margin-top: 20px;
+}
+
+/* Adjust header padding to prevent overlap */
+.fixed-header h1 {
+    padding-top: 20px;
+}


### PR DESCRIPTION
Add functionality to close the hamburger menu after a link is selected and adjust header styling to prevent overlap.

* **Header Styling:**
  - Add CSS rule to adjust header margin to prevent overlap.
  - Add CSS rule to adjust header padding to prevent overlap.

* **Hamburger Menu:**
  - Add event listener to close the hamburger menu after link selection.
  - Add function to close the hamburger menu after link selection.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/frankdoylezw/CSharp_Learning/pull/8?shareId=650b87d1-34bc-4391-9d56-53059656d491).